### PR TITLE
Add docker arguments to control the CMAKE_BUILD_TYPE and LLVM_ENABLE_ASSERTIONS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:24.10
+ARG ENABLE_ASSERTIONS=false
+ARG BUILD_TYPE=Release
 ENV TZ=Europe/Paris DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y sudo
@@ -54,14 +56,14 @@ RUN mkdir -p install
 RUN cmake llvm \
   -G Ninja \
   -B build \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
   -DCMAKE_INSTALL_PREFIX=./install \
   -DCMAKE_CXX_COMPILER=clang++ \
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_PREFIX_PATH=$HOME/usr \
   -DLLVM_BUILD_EXAMPLES=False \
   -DLLVM_TARGETS_TO_BUILD="Native" \
-  -DLLVM_ENABLE_ASSERTIONS=False \
+  -DLLVM_ENABLE_ASSERTIONS=${ENABLE_ASSERTIONS} \
   -DLLVM_ENABLE_LLD=On \
   -DLLVM_ENABLE_PROJECTS="mlir" \
   -DLLVM_USE_SPLIT_DWARF=On \
@@ -71,10 +73,9 @@ RUN cmake llvm \
   -DMLIR_LINK_MLIR_DYLIB=ON \
   -DMLIR_BUILD_MLIR_C_DYLIB=ON \
   -DLLVM_INSTALL_UTILS=ON \
-  -DMLIR_INCLUDE_INTEGRATION_TESTS=False
-RUN cmake --build build -t mlir-opt mlir-translate mlir-runner check-mlir install && rm -rf build
+  -DMLIR_INCLUDE_INTEGRATION_TESTS=False && \
+  cmake --build build -t mlir-opt mlir-translate mlir-runner check-mlir install && rm -rf build
 ENV LLVM_PREFIX=/home/mlir/llvm-project/install
 ENV PATH=/home/mlir/.local/bin:$PATH
 ENV PATH=/home/mlir/llvm-project/install/bin:$PATH
-RUN git clone https://github.com/mlir-school/mlir-list.git /home/mlir/mlir-list
 WORKDIR /home/mlir/mlir-list


### PR DESCRIPTION
Also remove the git clone of mlir-list: the tutorial is anyway mounting itself into the container, so this directory is shadowed at runtime.